### PR TITLE
Fix recfind to use parent.href

### DIFF
--- a/periscope/db.py
+++ b/periscope/db.py
@@ -128,19 +128,20 @@ class DBLayer(object, nllog.DoesLogging):
         raise tornado.gen.Return(results)
     
     @tornado.gen.coroutine
-    def getRecParentNames(self,par,pmap):
-        """ Gets all the child folder ids recurssively for a given folder - specially for exnodes"""
-        if par :
-            cursor = self.collection.find({"parent" : par,"mode":"directory"})
+    def getRecParentNames(self, par, pmap):
+        """ Gets all the child folder ids recursively for a given folder
+            (exnode specific)"""
+        if par:
+            cursor = self.collection.find({"name": par, "mode": "directory"})
             self.log.debug("find for Collection: [" + self._collection_name + "]")
             pmap[par] = 1
             while (yield cursor.fetch_next):
                 resource = cursor.next_object()
-                if resource == None:                 
+                if resource == None:
                     pass
                 else:
                     pmap[resource.get('id')] = 1
-                yield self.getRecParentNames(resource.get('id'),pmap)
+                yield self.getRecParentNames(resource.get('id'), pmap)
             raise tornado.gen.Return(pmap.keys())
         else:          
             raise tornado.gen.Return(None)

--- a/periscope/handlers/networkresourcehandler.py
+++ b/periscope/handlers/networkresourcehandler.py
@@ -270,7 +270,7 @@ class NetworkResourceHandler(SSEHandler, nllog.DoesLogging):
             in_split = value.split(",")
             if len(in_split) > 1:
                 raise tornado.gen.Return((yield process_in_query(key, in_split)[key]))
-            operators = ["lt", "lte", "gt", "gte","not","eq","null","recfind"]
+            operators = ["lt", "lte", "gt", "gte", "not", "eq", "null", "recfind", "reg"]
             for op in operators:
                 if value.startswith(op + "="):
                     if op == "not":
@@ -279,8 +279,11 @@ class NetworkResourceHandler(SSEHandler, nllog.DoesLogging):
                         tmpVal = yield process_value(key, value.lstrip(op + "="))
                         tmpVal = float(tmpVal)
                         raise tornado.gen.Return(tmpVal)
-                    elif op =="null":
+                    elif op == "null":
                         raise tornado.gen.Return(None)
+                    elif op == "reg":
+                        tmpVal = re.compile((yield process_value(key, value.lstrip(op + "="))), re.IGNORECASE)
+                        raise tornado.gen.Return(tmpVal)
                     elif op == "recfind":
                         tmpVal = yield process_value(key, value.lstrip(op + "="))
                         par = yield self.dblayer.getRecParentNames(tmpVal,{})


### PR DESCRIPTION
Fix regular expression subqueries on same field.

Any obvious issues with this merge?  The changes should allow our query tools to work correctly without any additional side effects.
